### PR TITLE
Correct RB120 conceptual problem number from 40 to 34

### DIFF
--- a/LSBot_Exercises/Ruby/RB120/conceptual/34.md
+++ b/LSBot_Exercises/Ruby/RB120/conceptual/34.md
@@ -1,5 +1,5 @@
 # RB120
-## Problem 40
+## Problem 34
 
 When should we use class inheritance vs. interface inheritance?
 


### PR DESCRIPTION
Question 34 is currently mislabeled as 40.

Additionally, questions 32 and 33 are duplicates of 29 and 30, but I didn't feel comfortable removing those, as there might be missing problems that 32 and 33 are actually supposed to be, so I didn't make an edit about that.

If 32 and 33 should simply be deleted, I can modify the numbers of the problems in my request to reflect that.